### PR TITLE
feat: migrate base utilities and api module

### DIFF
--- a/themes/2025/css/base.css
+++ b/themes/2025/css/base.css
@@ -137,3 +137,98 @@ body.custom-background {
     font-family: 'Courier New', monospace;
     letter-spacing: 2px;
 }
+
+/* 链接样式 */
+a {
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* 滚动条样式 */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #c1c1c1;
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #a1a1a1;
+}
+
+/* 动画 */
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* 显示/隐藏工具类 */
+.d-none { display: none !important; }
+.d-block { display: block !important; }
+.d-flex { display: flex !important; }
+
+/* 文本对齐 */
+.text-center { text-align: center; }
+.text-left { text-align: left; }
+.text-right { text-align: right; }
+
+/* 间距工具类 */
+.mt-0 { margin-top: 0 !important; }
+.mt-1 { margin-top: 0.25rem !important; }
+.mt-2 { margin-top: 0.5rem !important; }
+.mt-3 { margin-top: 1rem !important; }
+.mt-4 { margin-top: 1.5rem !important; }
+.mt-5 { margin-top: 3rem !important; }
+
+.mb-0 { margin-bottom: 0 !important; }
+.mb-1 { margin-bottom: 0.25rem !important; }
+.mb-2 { margin-bottom: 0.5rem !important; }
+.mb-3 { margin-bottom: 1rem !important; }
+.mb-4 { margin-bottom: 1.5rem !important; }
+.mb-5 { margin-bottom: 3rem !important; }
+
+.p-0 { padding: 0 !important; }
+.p-1 { padding: 0.25rem !important; }
+.p-2 { padding: 0.5rem !important; }
+.p-3 { padding: 1rem !important; }
+.p-4 { padding: 1.5rem !important; }
+.p-5 { padding: 3rem !important; }
+
+/* 颜色工具类 */
+.text-primary { color: var(--primary-color) !important; }
+.text-success { color: #28a745 !important; }
+.text-danger { color: #dc3545 !important; }
+.text-warning { color: #ffc107 !important; }
+.text-info { color: #17a2b8 !important; }
+.text-muted { color: #6c757d !important; }
+
+.bg-primary { background-color: var(--primary-color) !important; }
+.bg-success { background-color: #28a745 !important; }
+.bg-danger { background-color: #dc3545 !important; }
+.bg-warning { background-color: #ffc107 !important; }
+.bg-info { background-color: #17a2b8 !important; }
+.bg-light { background-color: #f8f9fa !important; }
+.bg-dark { background-color: #343a40 !important; }

--- a/themes/2025/css/layout.css
+++ b/themes/2025/css/layout.css
@@ -202,6 +202,132 @@
     100% { transform: rotate(360deg); }
 }
 
+/* 标签页容器及按钮样式 */
+.tabs {
+    background: white;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    margin-top: 20px;
+    border: 1px solid #e5e7eb;
+}
+
+.mobile-menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: #2c3e50;
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 10px;
+    border-radius: 5px;
+    transition: all 0.3s ease;
+}
+
+.mobile-menu-toggle:hover {
+    background: rgba(44, 62, 80, 0.1);
+    color: #667eea;
+}
+
+.tab-header {
+    display: flex;
+    background: linear-gradient(135deg, #f8faff 0%, #f1f5f9 100%);
+    border-bottom: 2px solid #e2e8f0;
+    overflow-x: auto;
+    padding: 0;
+    position: relative;
+}
+
+.tab-header::before {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, #667eea, transparent);
+}
+
+/* 标签导航按钮 */
+.tab-btn {
+    flex: 1;
+    min-width: 160px;
+    padding: 16px 24px;
+    border: none;
+    background: transparent;
+    color: #64748b;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    white-space: nowrap;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-radius: 0;
+}
+
+.tab-btn::before {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    width: 0;
+    height: 3px;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    transform: translateX(-50%);
+    transition: width 0.3s ease;
+    border-radius: 2px 2px 0 0;
+}
+
+.tab-btn:hover {
+    background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
+    color: #475569;
+    transform: translateY(-1px);
+}
+
+.tab-btn:hover::before {
+    width: 60%;
+}
+
+.tab-btn.active {
+    background: linear-gradient(135deg, #ffffff 0%, #f8faff 100%);
+    color: #667eea;
+    position: relative;
+    box-shadow: 0 -2px 8px rgba(102, 126, 234, 0.1);
+}
+
+.tab-btn.active::before {
+    width: 80%;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    box-shadow: 0 0 8px rgba(102, 126, 234, 0.4);
+}
+
+.tab-btn.active::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, #667eea, transparent);
+}
+
+.tab-btn i {
+    font-size: 16px;
+    margin-right: 0;
+    transition: transform 0.3s ease;
+}
+
+.tab-btn:hover i,
+.tab-btn.active i {
+    transform: scale(1.1);
+}
+
 /* 隐藏元素 */
 .hidden {
     display: none !important;

--- a/themes/2025/dashboard.html
+++ b/themes/2025/dashboard.html
@@ -190,6 +190,7 @@
     <div id="notification-container"></div>
     
     <!-- 引入JavaScript文件 -->
+    <script src="/js/api.js"></script>
     <script src="/js/utils.js"></script>
     <script src="/js/auth.js"></script>
     <script src="/js/dashboard.js"></script>

--- a/themes/2025/index.html
+++ b/themes/2025/index.html
@@ -152,6 +152,7 @@
             background: '{{background}}'
         };
     </script>
+    <script src="js/api.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/auth.js"></script>
     <script src="js/upload.js"></script>

--- a/themes/2025/js/api.js
+++ b/themes/2025/js/api.js
@@ -1,0 +1,327 @@
+// 前端 API 请求封装
+
+/**
+ * 通用请求方法
+ * @param {string} url 请求URL
+ * @param {Object} options fetch选项
+ * @returns {Promise<Object>} 解析后的JSON结果
+ */
+async function apiRequest(url, options = {}) {
+    const currentAuthToken =
+        (typeof window !== 'undefined' ? window.authToken : null) ||
+        localStorage.getItem('user_token');
+
+    const defaultOptions = {
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+
+    if (currentAuthToken) {
+        defaultOptions.headers['Authorization'] = 'Bearer ' + currentAuthToken;
+    }
+
+    const finalOptions = {
+        ...defaultOptions,
+        ...options,
+        headers: {
+            ...defaultOptions.headers,
+            ...options.headers
+        }
+    };
+
+    try {
+        const response = await fetch(url, finalOptions);
+
+        if (response.status === 401) {
+            handleAuthError();
+            throw new Error('认证失败，请重新登录');
+        }
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const result = await response.json();
+        return result;
+    } catch (error) {
+        console.error('API Request Error:', error);
+        throw error;
+    }
+}
+
+/**
+ * GET 请求
+ */
+async function apiGet(url, params = {}) {
+    const queryString = new URLSearchParams(params).toString();
+    const fullUrl = queryString ? `${url}?${queryString}` : url;
+    return apiRequest(fullUrl, { method: 'GET' });
+}
+
+/**
+ * POST 请求
+ */
+async function apiPost(url, data = {}) {
+    return apiRequest(url, {
+        method: 'POST',
+        body: JSON.stringify(data)
+    });
+}
+
+/**
+ * PUT 请求
+ */
+async function apiPut(url, data = {}) {
+    return apiRequest(url, {
+        method: 'PUT',
+        body: JSON.stringify(data)
+    });
+}
+
+/**
+ * DELETE 请求
+ */
+async function apiDelete(url) {
+    return apiRequest(url, { method: 'DELETE' });
+}
+
+/**
+ * 文件上传请求
+ */
+async function apiUpload(url, formData, onProgress = null) {
+    return new Promise((resolve, reject) => {
+        const currentAuthToken =
+            (typeof window !== 'undefined' ? window.authToken : null) ||
+            localStorage.getItem('user_token');
+        const xhr = new XMLHttpRequest();
+
+        if (onProgress) {
+            xhr.upload.addEventListener('progress', (e) => {
+                if (e.lengthComputable) {
+                    const percentComplete = (e.loaded / e.total) * 100;
+                    onProgress(percentComplete);
+                }
+            });
+        }
+
+        xhr.addEventListener('load', () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                try {
+                    const result = JSON.parse(xhr.responseText);
+                    resolve(result);
+                } catch (error) {
+                    reject(new Error('响应解析失败'));
+                }
+            } else if (xhr.status === 401) {
+                handleAuthError();
+                reject(new Error('认证失败，请重新登录'));
+            } else {
+                reject(new Error(`上传失败: ${xhr.status} ${xhr.statusText}`));
+            }
+        });
+
+        xhr.addEventListener('error', () => {
+            reject(new Error('网络错误'));
+        });
+
+        xhr.addEventListener('timeout', () => {
+            reject(new Error('请求超时'));
+        });
+
+        xhr.open('POST', url);
+        if (currentAuthToken) {
+            xhr.setRequestHeader('Authorization', 'Bearer ' + currentAuthToken);
+        }
+        xhr.timeout = 300000;
+        xhr.send(formData);
+    });
+}
+
+/**
+ * 文件下载请求
+ */
+async function apiDownload(url, filename = 'download') {
+    try {
+        const currentAuthToken =
+            (typeof window !== 'undefined' ? window.authToken : null) ||
+            localStorage.getItem('user_token');
+        const headers = {};
+
+        if (currentAuthToken) {
+            headers['Authorization'] = 'Bearer ' + currentAuthToken;
+        }
+
+        const response = await fetch(url, { headers });
+
+        if (response.status === 401) {
+            handleAuthError();
+            throw new Error('认证失败，请重新登录');
+        }
+
+        if (!response.ok) {
+            throw new Error(`下载失败: ${response.status} ${response.statusText}`);
+        }
+
+        const blob = await response.blob();
+        const contentDisposition = response.headers.get('Content-Disposition');
+        if (contentDisposition) {
+            const matches = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+            if (matches != null && matches[1]) {
+                filename = matches[1].replace(/['"]/g, '');
+            }
+        }
+
+        const urlObj = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = urlObj;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        window.URL.revokeObjectURL(urlObj);
+
+        return { success: true, filename };
+    } catch (error) {
+        console.error('Download Error:', error);
+        throw error;
+    }
+}
+
+/**
+ * 批量请求
+ */
+async function apiBatch(requests, concurrency = 3) {
+    const results = [];
+    for (let i = 0; i < requests.length; i += concurrency) {
+        const batch = requests.slice(i, i + concurrency);
+        const batchResults = await Promise.allSettled(batch);
+        results.push(...batchResults);
+    }
+    return results;
+}
+
+/**
+ * 重试请求
+ */
+async function apiRetry(requestFn, maxRetries = 3, delay = 1000) {
+    let lastError;
+    for (let i = 0; i <= maxRetries; i++) {
+        try {
+            return await requestFn();
+        } catch (error) {
+            lastError = error;
+            if (error.message.includes('401') || error.message.includes('认证失败')) {
+                throw error;
+            }
+            if (i < maxRetries) {
+                await new Promise(resolve => setTimeout(resolve, delay * (i + 1)));
+            }
+        }
+    }
+    throw lastError;
+}
+
+/**
+ * 处理认证错误
+ */
+function handleAuthError() {
+    if (typeof window !== 'undefined') {
+        window.authToken = null;
+    }
+    localStorage.removeItem('user_token');
+    if (typeof UserAuth !== 'undefined') {
+        try {
+            UserAuth.removeToken();
+            UserAuth.removeUserInfo();
+            UserAuth.updateUI();
+        } catch (e) {
+            console.error('处理认证错误失败:', e);
+        }
+    } else {
+        location.reload();
+    }
+}
+
+/**
+ * 设置认证令牌
+ */
+function setAuthToken(token) {
+    if (typeof window !== 'undefined') {
+        window.authToken = token;
+    }
+    if (token) {
+        localStorage.setItem('user_token', token);
+    } else {
+        localStorage.removeItem('user_token');
+    }
+}
+
+/**
+ * 获取认证令牌
+ */
+function getAuthToken() {
+    return (typeof window !== 'undefined' ? window.authToken : null) || localStorage.getItem('user_token');
+}
+
+/**
+ * 检查是否已认证
+ */
+function isAuthenticated() {
+    const currentAuthToken =
+        (typeof window !== 'undefined' ? window.authToken : null) ||
+        localStorage.getItem('user_token');
+    return !!currentAuthToken;
+}
+
+/**
+ * 请求拦截器（占位）
+ */
+function addRequestInterceptor(interceptor) {
+    // 可在此实现请求拦截逻辑
+}
+
+/**
+ * 响应拦截器（占位）
+ */
+function addResponseInterceptor(interceptor) {
+    // 可在此实现响应拦截逻辑
+}
+
+// 常用API端点
+const API_ENDPOINTS = {
+    CONFIG: '/',
+    SHARE_TEXT: '/share/text/',
+    SHARE_FILE: '/share/file/',
+    SHARE_SELECT: '/share/select/',
+    USER_PROFILE: '/user/profile',
+    USER_STATS: '/user/stats',
+    USER_FILES: '/user/files',
+    USER_FILE_DETAIL: (id) => `/user/files/${id}`,
+    USER_CHANGE_PASSWORD: '/user/change-password',
+    USER_LOGOUT: '/user/logout',
+    USER_SYSTEM_INFO: '/user/system-info'
+};
+
+// 导出（用于模块系统）
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        apiRequest,
+        apiGet,
+        apiPost,
+        apiPut,
+        apiDelete,
+        apiUpload,
+        apiDownload,
+        apiBatch,
+        apiRetry,
+        setAuthToken,
+        getAuthToken,
+        isAuthenticated,
+        handleAuthError,
+        addRequestInterceptor,
+        addResponseInterceptor,
+        API_ENDPOINTS
+    };
+}
+

--- a/themes/2025/js/main.js
+++ b/themes/2025/js/main.js
@@ -67,11 +67,8 @@ class FileCodeBoxApp {
      */
     async loadConfig() {
         try {
-            const response = await fetch('/', {
-                method: 'POST'
-            });
-            const result = await response.json();
-            
+            const result = await apiPost(API_ENDPOINTS.CONFIG, {});
+
             if (result.code === 200) {
                 AppState.config = result.data;
                 console.log('应用配置已加载:', AppState.config);


### PR DESCRIPTION
## Summary
- port admin base utilities into shared base stylesheet
- add front-end API wrapper and load it on user pages
- fetch app config through new API helper

## Testing
- `go test ./...` *(fails: command hung and was terminated)*
- `go build ./...` *(fails: command hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c643625b148320a432282e7bfcbaa3